### PR TITLE
Fix errant space in filename

### DIFF
--- a/AstroBinUpload.py
+++ b/AstroBinUpload.py
@@ -1038,13 +1038,13 @@ def main():
     astroBin_df = create_astrobin_output(aggregated_df, params['filters'])
 
     # Export summary to a text file
-    summary_txt = os.path.basename(directory_paths[0]) + " session summary.txt"
+    summary_txt = os.path.basename(directory_paths[0]) + "session_summary.txt"
     with open(summary_txt, 'w') as file:
         file.write(summary)
     print(f"\nProcessing summary exported to {summary_txt}")
 
     # Export final data to CSV
-    output_csv = os.path.basename(directory_paths[0]) + " acquisition.csv"
+    output_csv = os.path.basename(directory_paths[0]) + "acquisition.csv"
     astroBin_df.to_csv(output_csv, index=False)
     print(f"\nAstroBin data exported to {output_csv}")
     


### PR DESCRIPTION
**What**

After the code completes, it leaves two files named:
` acquisition.csv` 
` session summary.txt`

This PR removes the errant space and adds an underscore instead of a space for the filename.

**Proof**

```
(base) x@europa:~/AstroBinUploader$ ls -l | grep -E 'acqui|session'
-rw-r--r-- 1 x x  2500 Dec 15 19:09 acquisition.csv
-rw-r--r-- 1 x x   430 Dec 15 19:07 session_summary.txt
```
